### PR TITLE
Rewrite position mapping code

### DIFF
--- a/Agda.cabal
+++ b/Agda.cabal
@@ -938,6 +938,7 @@ test-suite agda-tests
       Internal.Interaction.Highlighting.Range
       Internal.Interaction.Library
       Internal.Interaction.Options
+      Internal.Interaction.Lsp.Interaction
       Internal.Interaction.Lsp.Tests
       Internal.Interaction.Lsp.Utils
       Internal.Syntax.Abstract.Name

--- a/test/Internal/Interaction/Lsp/Interaction.hs
+++ b/test/Internal/Interaction/Lsp/Interaction.hs
@@ -1,0 +1,45 @@
+module Internal.Interaction.Lsp.Interaction (tests) where
+
+import qualified Language.LSP.Protocol.Lens as Lsp
+import Language.LSP.Protocol.Types
+import Language.LSP.Test
+
+import Control.Monad.IO.Class
+
+import qualified Data.Text as Text
+import Data.Default
+
+import Test.Tasty.HUnit
+
+import Internal.Helpers
+import Internal.Interaction.Lsp.Utils
+import Control.Applicative.Combinators
+
+import Agda.LSP.Commands
+import Agda.LSP.Goal
+import Agda.Utils.Lens
+
+giveAddsParentheses :: TestTree
+giveAddsParentheses = testCase "Give adds parentheses" $ runAgdaSession def lspRoot $ do
+  doc <- openDoc "Give.agda" "agda"
+  let uriDoc = doc ^. Lsp.uri
+  waitForSuccessfulReload
+
+  insertText doc (Position 7 23) "add {!!} {!!} "
+  (liftIO . print) =<< documentContents doc
+
+  [Goal {goalRange = Range (Position 7 20) (Position 7 39)}] <- goalQuery doc Query_AllGoals
+  res <- executeCommand (toCommand "Give" (Command_Give uriDoc (Position 7 20)))
+
+  newContents <- getDocumentEdit doc
+  liftIO $ Text.lines newContents !! 7 @?= "add (suc x) y = suc (add {!!} {!!})"
+
+  ( [ Goal {goalRange = Range (Position 7 25) (Position 7 29)}
+    , Goal {goalRange = Range (Position 7 30) (Position 7 34)} ] ) <- goalQuery doc Query_AllGoals
+
+  pure ()
+
+tests :: TestTree
+tests = testGroup "Internal.Interaction.Lsp.Interaction"
+  [ giveAddsParentheses
+  ]

--- a/test/Internal/Interaction/Lsp/Tests.hs
+++ b/test/Internal/Interaction/Lsp/Tests.hs
@@ -1,6 +1,9 @@
 module Internal.Interaction.Lsp.Tests (tests) where
 
+import qualified Internal.Interaction.Lsp.Interaction as Interaction
 import Internal.Helpers
 
 tests :: TestTree
-tests = testGroup "Internal.Interaction.Lsp.Tests" []
+tests = testGroup "Internal.Interaction.Lsp.Tests"
+  [ Interaction.tests
+  ]


### PR DESCRIPTION
The general intuition here is that instead of trying to modify the current TCState, and hope that the client matches up with it, we now save the speculated state of the document (and its equivalent TC state) in a snapshot. If we then receive an edit that matches this document, we switch to this snapshot, otherwise we discard it.

Most of the complexity here is how we handle positions. When we give a goal, we now perform the following steps:

 1. Save all existing highlighting information and interaction points.
 2. Give the expression, highlight it, and generate a text edit from it.
 3. Offset any new interaction points and highlighting info to remove the leading hole information. For instance, we offset by -3 in the below, to account for removing `{! `.
    ```agda
    x = {! foo {!!} !}
    -- => 
    x = foo
    ```
 4. Apply both the pending and new text edits to any existing highlighting info and interaction points, updating them to the new state of the document.
 5. Reset the position delta of the file.